### PR TITLE
Fixes bug in clearing multiple lines

### DIFF
--- a/game.py
+++ b/game.py
@@ -19,13 +19,13 @@ class Game:
         self.dimensions = Dimensions(x, y)
         self.current_piece = None
         self.next_pieces = [deepcopy(random.choice(SHAPES)) for _ in range(3)]
-
+        
         self._bottom = [(i, y) for i in range(x)]  # bottom
         self._lateral = [(0, i) for i in range(y)]  # left
         self._lateral.extend([(x - 1, i) for i in range(y)])  # right
 
         self.grid = self._bottom + self._lateral
-
+        
         self.game = []
         self.score = 0
         self.speed = 1
@@ -44,8 +44,9 @@ class Game:
 
     def clear_rows(self):
         lines = 0
-
-        for item, count in Counter(y for _, y in self.game).most_common():
+        counter = Counter(y for _, y in self.game).most_common()
+        counter.sort() # sort to eliminate lines ordered by Y value
+        for item, count in counter:
             if count == len(self._bottom) - 2:
                 self.game = [(x, y) for (x, y) in self.game if y != item]  # remove row
                 self.game = [


### PR DESCRIPTION
The bug happens when you clear more than one line. The previous code
didn't guarantee that the lines were cleared in the correct order.
The correct order should be from top to bottom, or else an indexation
problem occurs due to dropping blocks.

For example, if we delete lines 29 and 28, in this order, then line 29
will be cleared, line 28 will became 29 (and consequently 27 into 28),
then line 28 will also be cleared (ex-27). In effect, the game deleted the
wrong line and the line that should have been deleted remains in play.

P.S.: Thanks to Dinis, Isabel and Camila (NMECS: 98452, 93343, 97880) for
helping us track and fix this bug.